### PR TITLE
Add Kustomize deployment for Feed API REST

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feed-api-rest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: feed-api-rest
+  template:
+    metadata:
+      labels:
+        app: feed-api-rest
+    spec:
+      containers:
+        - name: feed-api-rest
+          image: feed-api-rest
+          ports:
+            - containerPort: 8080

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - service.yaml
 images:
   - name: feed-api-rest
+    newName: ghcr.io/s3nthilg0pal/feedapi
     newTag: latest

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+images:
+  - name: feed-api-rest
+    newTag: latest

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: feed-api-rest
+spec:
+  selector:
+    app: feed-api-rest
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add Deployment, Service, and Kustomization to deploy the Feed API REST component

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aac85256f883339c17b05645887e03