### PR TITLE
Specify node for feed-api deployment

### DIFF
--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -7,3 +7,6 @@ images:
   - name: feed-api-rest
     newName: ghcr.io/s3nthilg0pal/feedapi
     newTag: latest
+
+patchesStrategicMerge:
+  - node-selector.yaml

--- a/k8s/node-selector.yaml
+++ b/k8s/node-selector.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feed-api-rest
+spec:
+  template:
+    spec:
+      nodeName: homserservervm


### PR DESCRIPTION
## Summary
- ensure feed-api pods schedule on homserservervm node
- add kustomize patch for node selection

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `kubectl kustomize k8s` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aace7a99888333968ffda245cf09e9