### PR TITLE
Use MetalLB load balancer for feed API

### DIFF
--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -10,3 +10,4 @@ images:
 
 patchesStrategicMerge:
   - node-selector.yaml
+  - service-loadbalancer.yaml

--- a/k8s/service-loadbalancer.yaml
+++ b/k8s/service-loadbalancer.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: feed-api-rest
+spec:
+  type: LoadBalancer


### PR DESCRIPTION
## Summary
- Expose feed API service via a MetalLB-managed load balancer
- Include load balancer patch in kustomization

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68aacfdf2f40833388f3c5144ba002e2