### PR TITLE
fix: add service port name

### DIFF
--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -6,6 +6,7 @@ spec:
   selector:
     app: feed-api-rest
   ports:
-    - port: 8080
+    - name: http-8080
+      port: 8080
       targetPort: 8080
   type: ClusterIP


### PR DESCRIPTION
## Summary
- add name to service port to satisfy Kubernetes service validation

## Testing
- `kustomize build k8s` *(fails: command not found: kustomize)*


------
https://chatgpt.com/codex/tasks/task_e_68aad63f746c83338a08b8a9e4b54e3a