### PR TITLE
Add OpenSearch search endpoint and indexing service

### DIFF
--- a/Api/Endpoints/Search.cs
+++ b/Api/Endpoints/Search.cs
@@ -1,0 +1,23 @@
+using Api.Infrastructure;
+using Application.Articles.SearchArticles;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Api.Endpoints;
+
+public class Search : EndpointGroupBase
+{
+    public override void Map(WebApplication app)
+    {
+        app.MapGroup(this)
+            .MapGet(Get);
+    }
+
+    public async Task<Ok<IEnumerable<ArticleSearchDocument>>> Get(string term, IMediator mediator)
+    {
+        var request = new SearchArticlesQuery(term);
+        var articles = await mediator.Send(request);
+        return TypedResults.Ok(articles);
+    }
+}
+

--- a/Api/appsettings.Development.json
+++ b/Api/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "OpenSearch": {
+    "Uri": "http://localhost:9200"
   }
 }

--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="OpenSearch.Client" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/Articles/SearchArticles/ArticleSearchDocument.cs
+++ b/Application/Articles/SearchArticles/ArticleSearchDocument.cs
@@ -1,0 +1,11 @@
+namespace Application.Articles.SearchArticles;
+
+public class ArticleSearchDocument
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+    public string? Content { get; set; }
+    public string? Text { get; set; }
+    public string? Link { get; set; }
+}
+

--- a/Application/Articles/SearchArticles/SearchArticlesQuery.cs
+++ b/Application/Articles/SearchArticles/SearchArticlesQuery.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using OpenSearch.Client;
+
+namespace Application.Articles.SearchArticles;
+
+public record SearchArticlesQuery(string Term) : IRequest<IEnumerable<ArticleSearchDocument>>;
+
+public class SearchArticlesQueryHandler : IRequestHandler<SearchArticlesQuery, IEnumerable<ArticleSearchDocument>>
+{
+    private readonly IOpenSearchClient _client;
+
+    public SearchArticlesQueryHandler(IOpenSearchClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<IEnumerable<ArticleSearchDocument>> Handle(SearchArticlesQuery request, CancellationToken cancellationToken)
+    {
+        var response = await _client.SearchAsync<ArticleSearchDocument>(s => s
+            .Query(q => q
+                .MultiMatch(m => m
+                    .Fields(f => f
+                        .Field(p => p.Title)
+                        .Field(p => p.Content)
+                        .Field(p => p.Text)
+                        .Field(p => p.Link)
+                    )
+                    .Query(request.Term)
+                )
+            ), cancellationToken);
+
+        return response.Documents;
+    }
+}
+

--- a/Dockerfile.indexer
+++ b/Dockerfile.indexer
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
+
+COPY . /source
+
+WORKDIR /source/SearchIndexer
+
+ARG TARGETARCH
+
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet publish -a ${TARGETARCH/amd64/x64} --use-current-runtime --self-contained false -o /app
+
+FROM mcr.microsoft.com/dotnet/runtime:9.0-alpine AS final
+WORKDIR /app
+COPY --from=build /app .
+USER $APP_UID
+ENTRYPOINT ["dotnet", "SearchIndexer.dll"]
+

--- a/Feed.sln
+++ b/Feed.sln
@@ -13,10 +13,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application", "Application\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.GraphQL", "Api.GraphQL\Api.GraphQL.csproj", "{E92AA74B-D4B8-4493-BD46-89611D7EA15A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchIndexer", "SearchIndexer\SearchIndexer.csproj", "{2DD170FC-112A-4DDA-943D-162F47CEEC78}"
+EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9223E0F9-F1A1-40C6-B7B7-B15EAAE28227}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -36,10 +38,14 @@ Global
 		{3D753478-6048-446B-B51D-B6DE3358E848}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3D753478-6048-446B-B51D-B6DE3358E848}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E92AA74B-D4B8-4493-BD46-89611D7EA15A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E92AA74B-D4B8-4493-BD46-89611D7EA15A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E92AA74B-D4B8-4493-BD46-89611D7EA15A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E92AA74B-D4B8-4493-BD46-89611D7EA15A}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {E92AA74B-D4B8-4493-BD46-89611D7EA15A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E92AA74B-D4B8-4493-BD46-89611D7EA15A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E92AA74B-D4B8-4493-BD46-89611D7EA15A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {2DD170FC-112A-4DDA-943D-162F47CEEC78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {2DD170FC-112A-4DDA-943D-162F47CEEC78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {2DD170FC-112A-4DDA-943D-162F47CEEC78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {2DD170FC-112A-4DDA-943D-162F47CEEC78}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using System;
 using Application.Common.Infrastructure;
 using Microsoft.EntityFrameworkCore;
+using OpenSearch.Client;
 
 namespace Infrastructure;
 
@@ -21,5 +22,9 @@ public static class DependencyInjection
 
         builder.Services.AddScoped<IFeedContext>(options => options.GetRequiredService<FeedContext>());
         builder.Services.AddSingleton(TimeProvider.System);
+
+        var uri = builder.Configuration["OpenSearch:Uri"];
+        var settings = new ConnectionSettings(new Uri(uri)).DefaultIndex("articles");
+        builder.Services.AddSingleton<IOpenSearchClient>(new OpenSearchClient(settings));
     }
 }

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
+    <PackageReference Include="OpenSearch.Client" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SearchIndexer/Program.cs
+++ b/SearchIndexer/Program.cs
@@ -1,0 +1,19 @@
+using Application.Common.Infrastructure;
+using Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using OpenSearch.Client;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.AddInfrastructureServices();
+
+using var host = builder.Build();
+using var scope = host.Services.CreateScope();
+
+var context = scope.ServiceProvider.GetRequiredService<IFeedContext>();
+var client = scope.ServiceProvider.GetRequiredService<IOpenSearchClient>();
+
+var articles = await context.Articles.ToListAsync();
+await client.IndexManyAsync(articles, "articles");
+

--- a/SearchIndexer/SearchIndexer.csproj
+++ b/SearchIndexer/SearchIndexer.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="OpenSearch.Client" Version="2.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>
+

--- a/SearchIndexer/appsettings.json
+++ b/SearchIndexer/appsettings.json
@@ -4,12 +4,6 @@
   },
   "OpenSearch": {
     "Uri": "http://opensearch:9200"
-  },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
+  }
 }
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,24 @@ services:
       target: final
     ports:
       - 8083:8080
+    depends_on:
+      - opensearch
+
+  indexer:
+    build:
+      context: .
+      dockerfile: Dockerfile.indexer
+      target: final
+    depends_on:
+      - opensearch
+
+  opensearch:
+    image: opensearchproject/opensearch:2.12.0
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+    ports:
+      - 9200:9200
 
 # The commented out section below is an example of how to define a PostgreSQL
 # database that your application can use. `depends_on` tells Docker Compose to


### PR DESCRIPTION
## Summary
- add OpenSearch client registration and configuration
- implement article search query and API endpoint
- create indexing console app and docker support

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aadd2cf77c833382f96d5a75b845d9